### PR TITLE
automatically adjust PSF filter criteria, use residual and position a…

### DIFF
--- a/sphot/core.py
+++ b/sphot/core.py
@@ -113,8 +113,10 @@ def run_scalefit(galaxy,filtername,base_params,allow_refit,
     kwargs_sersic_init  = dict(fit_to='data',progress=progress)
     kwargs_sersic_iter  = dict(fit_to='psf_sub_data',progress=progress)
     kwargs_psf          = dict(fit_to='sersic_residual',progress=progress,**kwargs)
-    kwargs_rmsky_sersic = dict(fit_to='residual_masked',remove_from=['sersic_residual','residual_masked','residual'],repeat=3,**kwargs)
-    kwargs_rmsky_psf    = dict(fit_to='residual_masked',remove_from=['psf_sub_data','residual_masked','residual'],repeat=3,**kwargs)
+    kwargs_rmsky_sersic = dict(fit_to='residual_masked',
+                               remove_from=['sersic_residual','residual_masked','residual'],repeat=3,**kwargs)
+    kwargs_rmsky_psf    = dict(fit_to='residual_masked',
+                               remove_from=['psf_sub_data','residual_masked','residual'],repeat=3,**kwargs)
     if allow_refit:
         kwargs_sersic_refit = dict(fit_to='psf_sub_data',max_iter=20,progress=progress) 
         kwargs_sersic_refit_iter = dict(fit_to='psf_sub_data',max_iter=10,progress=progress)

--- a/sphot/data.py
+++ b/sphot/data.py
@@ -243,11 +243,16 @@ class CutoutData():
         
     def remove_sky(self,fit_to='residual_masked',remove_from='psf_sub_data',**kwargs):
         N_repeat = kwargs.get('repeat',1)
+        
+        # sky model = sum of all sky models fitted during the iterations
+        sky_model_total = np.zeros_like(self.data)
         for _ in range(N_repeat):
             self.fit_sky(fit_to=fit_to,**kwargs)
+            sky_model_total += self.sky_model
             for attr in np.atleast_1d(np.squeeze(remove_from)):
                 _data = getattr(self,attr)
                 setattr(self,attr,_data-self.sky_model)    
+        self.sky_model = sky_model_total
     
     def fit_sky(self,fit_to='residual_masked',poly_deg=1,
                 radius_in=7,width=7,plot=False,**kwargs):


### PR DESCRIPTION
Addition of automatic routine ```_update_filter_criteria``` to relax the PSF quality cut criteria if needed.
Addresses https://github.com/SterlingYM/sphot/issues/2 and https://github.com/SterlingYM/sphot/issues/3, and fixes a bug in sky subtraction. The ```sky_mode``` now represents the actual sky model, instead of the small adjustment made after iterative sky subtraction.