### PR TITLE
Migrate to photutils v3.0.0

### DIFF
--- a/sphot/aperture.py
+++ b/sphot/aperture.py
@@ -6,7 +6,7 @@ from scipy.interpolate import interp1d
 from astropy.convolution import convolve
 from astropy.nddata import block_reduce, Cutout2D
 from astropy import units as u
-from photutils.psf.matching import TopHatWindow, create_matching_kernel
+from photutils.psf_matching import TopHatWindow, make_kernel
 from photutils.aperture import EllipticalAperture, aperture_photometry
 
 from copy import deepcopy
@@ -64,7 +64,10 @@ def aperture_routine(galaxy,petro=0.5,center_mask=3.5,plot=True,
         aper_sci = iso_apers.get_aper_at(petro=petro)
         # frac_enclosed = iso_apers.frac_enclosed_at_aper_sci
         if plot:
-            iso_apers.plot()
+            try:
+                iso_apers.plot()
+            except Exception as e:
+                logger.warning(f'Failed to plot isophotal apertures: {e}')
     else:
         logger.info('Using custom aperture...')
         aper_sci = custom_aperture
@@ -82,7 +85,10 @@ def aperture_routine(galaxy,petro=0.5,center_mask=3.5,plot=True,
         aperphot.measure_frac(measure_on=measure_on + '_filled')
         aperphot.calc_mag()
         if plot:
-            aperphot.plot()
+            try:
+                aperphot.plot()
+            except Exception as e:
+                logger.warning(f'Failed to plot aperture photometry: {e}')
         cutoutdata.aper_petro = petro
         cutoutdata.mag_raw = aperphot.magAB
         cutoutdata.mag_raw_err = aperphot.magAB_err
@@ -126,7 +132,10 @@ def aperture_routine(galaxy,petro=0.5,center_mask=3.5,plot=True,
                             mode='grid')
         aperphot.calc_mag()
         if plot:
-            aperphot.plot()
+            try:
+                aperphot.plot(title=f'PSF corr: {PSF_corr_base_filter} -> {filt}:\ndmag={aperphot.magAB - _cutoutdata.mag_raw:.2f} mag')
+            except Exception as e:
+                logger.warning(f'Failed to plot PSF correction photometry: {e}')
         cutoutdata.dmag_PSFcorr = aperphot.magAB - _cutoutdata.mag_raw
         cutoutdata.dmag_PSFcorr_err = np.sqrt(aperphot.magAB_err**2 + _cutoutdata.mag_raw_err**2)
     
@@ -165,7 +174,7 @@ def prepare_blurring_kernel(galaxy,filt,blur_to,
     psf_base_cropped_ds = block_reduce(psf_base_cropped,os)
 
     # Calculate the blurring kernel
-    psf_matching_kernel = create_matching_kernel(psf_cropped_ds, psf_base_cropped_ds, window=window)
+    psf_matching_kernel = make_kernel(psf_cropped_ds, psf_base_cropped_ds, window=window)
 
     return psf_matching_kernel, psf_cropped_ds, psf_base_cropped_ds
 
@@ -218,7 +227,7 @@ def fill_nans(galaxy,apertures,
                     mask_img = mask_outer & (~mask_inner)
                     median_val = np.nanmedian(data[mask_img])
                     s = mask_img & (~np.isfinite(data))
-                    if s.sum() <= max_nan_frac * mask_img.sum():
+                    if s.sum() <= max_nan_frac * mask_img.sum() or (replace_with=='median'):
                         data_filled[s] = median_val
                     else:
                         data_filled[s] = getattr(cutoutdata,replace_with)[s].copy()
@@ -520,7 +529,7 @@ class CutoutDataPhotometry():
         else:
             self.magAB_err = np.nan
             
-    def plot(self):
+    def plot(self,title=None):
         fig,(ax1,ax2) = plt.subplots(1,2,figsize=(8,4))
         plt.subplots_adjust(wspace=0.01)
         norm,offset = astroplot(self.data_flux,ax=ax1)
@@ -531,6 +540,8 @@ class CutoutDataPhotometry():
         ax1.text(0.05,0.95,f'{self.cutoutdata.filtername}: {self.magAB:.2f} +/- {self.magAB_err:.2f} mag',
                  transform=ax1.transAxes,fontsize=10,bbox=dict(facecolor='white',alpha=0.3,edgecolor='none'),
                  va='top',ha='left')
+        if title:
+            ax1.set_title(title,fontsize=13)
             
     def __repr__(self):
         return f'{self.cutoutdata.filtername}: {self.magAB:.2f} +/- {self.magAB_err:.2f} mag'

--- a/sphot/data.py
+++ b/sphot/data.py
@@ -94,6 +94,7 @@ class CutoutData():
         self.psf_blurring = psf_blurring
         self.fix_psf()
         self.calc_psf_sigma()
+        return self.psf,self.psf_sigma
     
     def determine_psf_blurring(self):
         ''' determine the best PSF blurring value based on the number of stars detected '''
@@ -122,8 +123,8 @@ class CutoutData():
                                         self.psf_oversample)
             daofinder = DAOStarFinder(threshold=bkg_std*2,
                                       fwhm=psf_sigma*2.33,
-                                      roundhi=1.0, roundlo=-1.0,
-                                      sharplo=0.20, sharphi=1.0)
+                                      roundness_range=(-1.0, 1.0),
+                                      sharpness_range=(0.20, 1.0))
             star_cat = daofinder.find_stars(data_bksub)
             psf_sigma_vals.append(psf_sigma)
             N_stars_found.append(len(star_cat))
@@ -369,7 +370,11 @@ class MultiBandCutout():
                             logger.error(f'Error with {key}: {e}')
                             continue
                 else:
-                    f.create_dataset(g_key,data=str_to_json(g_val))
+                    try:
+                        f.create_dataset(g_key,data=str_to_json(g_val))
+                    except Exception as e:
+                        logger.error(f'Error with {g_key}: {e}')
+                        continue
         logger.info(f'Saved to {filepath}')
         
     def fill_nans(self,isophot_base_filter,
@@ -469,13 +474,17 @@ def _calc_psf_sigma(data,psf_oversample):
     return psf_sigma
 
 def str_to_json(s):
-    ''' encode string to json-readable format. 
+    ''' encode string to json-readable format.
     This is a helper function for saving h5 files.'''
     if isinstance(s,str):
         return json.dumps(s).encode('utf-8')
     elif isinstance(s,list):
-        if isinstance(s[0],str):
+        if len(s) > 0 and isinstance(s[0],str):
             return json.dumps(s).encode('utf-8')
+        return s
+    elif isinstance(s, u.Quantity):
+        # photutils v3 returns angles as Quantity; store the bare value
+        return np.asarray(s.value)
     else:
         return s
 

--- a/sphot/default_config.toml
+++ b/sphot/default_config.toml
@@ -22,9 +22,10 @@ th_iter = 10 # N_iteration between min and max
 mask_aper_size_in_r_eff = 3.5
 raise_error = false
 residual_clip_sigma = 15.0 # keep this high to avoid over-masking
+psf_blur_factors = [0.8,1.2] # try changing the PSF width by these factors times psf_blur values
 
 # finder/grouper/bkg parameters
-finder_kwargs = {roundhi=1.0, roundlo=-1.0, sharplo=0.20, sharphi=1.0}
+finder_kwargs = {roundness_range=[-1.0, 1.0], sharpness_range=[0.20, 1.0]}
 grouper_separation_in_psfsigma = 2
 bkg_sigma_clip = 3.0
 bkg_box_size = [10,10]
@@ -37,7 +38,6 @@ PSFPhotometry_fitter_maxiters = 300
 PSFPhotometry_maxiters = 5
 PSFPhotometry_mode = 'new'
 PSFPhotometry_fit_shape = [3,3] # pixels. use small number for crowded fields
-PSFPhotometry_multiprocessing = false
 modelimg_render_shape = [25,25]
 PSFPhotometry_group_warning_threshold = 10
 
@@ -62,5 +62,5 @@ measure_on = 'psf_sub_data'
 error_on = 'psf_sub_data_error'
 measure_sky_on='residual_masked'
 fill_max_nan_frac=0.7
-fill_replace_with='sersic_modelimg'
+fill_replace_with='median'#'sersic_modelimg'
 PSF_corr_base_filter='F090W'

--- a/sphot/psf.py
+++ b/sphot/psf.py
@@ -4,6 +4,7 @@ from .plotting import astroplot
 from tqdm.auto import tqdm
 import warnings
 from astropy.utils.exceptions import AstropyUserWarning
+import traceback
 
 from scipy.ndimage import gaussian_filter
 from astropy.nddata import overlap_slices
@@ -23,6 +24,12 @@ from .data import get_data_annulus
 from .logging import logger
 from .config import config
 
+def get_full_traceback(e):
+    ''' Get the full traceback of an exception as a string. '''
+    tb_lines = traceback.format_exception(type(e), e, e.__traceback__)
+    tb_text = ''.join(tb_lines)
+    return tb_text
+
 class PSFFitter():
     ''' A class to perform PSF fitting. '''
     def __init__(self,cutoutdata):
@@ -30,12 +37,34 @@ class PSFFitter():
         self.psf_sigma = cutoutdata.psf_sigma
         
             # PSF image to model
-        self.psf_model = ImagePSF(
-            cutoutdata.psf, flux=1.0,
+        self.psf_model = self.psf_img2model(cutoutdata.psf,cutoutdata.psf_oversample)
+        
+    def psf_img2model(self,psfimg,psf_oversample):
+        psf_model = ImagePSF(
+            psfimg, flux=1.0,
             x_0=0, y_0=0, 
-            oversampling=cutoutdata.psf_oversample, 
+            oversampling=psf_oversample, 
             fill_value=0.0
-            )   
+            )
+        return psf_model
+    
+    def update_psf_blur(self,psf_blur):
+        ''' Update the PSF model by convolving the PSF image with a Gaussian kernel.
+        
+        Args:
+            psf_blur (float): the sigma of the Gaussian kernel in pixel units.
+        '''
+        if psf_blur:
+            logger.debug(f'Convolving (blurring) PSF with sigma={psf_blur} pix')
+            psf_blurred, psf_sigma = self.cutoutdata.blur_psf(psf_blur)
+            self.psf_model = self.psf_img2model(psf_blurred,self.cutoutdata.psf_oversample)
+            self.psf_sigma = psf_sigma
+        else:
+            logger.debug(f'Using original PSF without blurring')
+            self.psf_model = self.psf_img2model(self.cutoutdata.psf,self.cutoutdata.psf_oversample)
+            self.psf_sigma = self.cutoutdata.psf_sigma
+            
+        return self.psf_model,self.psf_sigma
         
     def fit(self,fit_to='sersic_residual',**kwargs):
         ''' Perform PSF fitting. 
@@ -58,10 +87,11 @@ class PSFFitter():
         blur_psf_dict = config['prep'].get('blur_psf',False)
         blur_psf = blur_psf_dict.get(self.cutoutdata.filtername,False) if isinstance(blur_psf_dict,dict) else blur_psf_dict
         if blur_psf:
-            logger.info(f'Convolving (blurring) PSF with sigma={blur_psf} pix')
-            self.cutoutdata.blur_psf(blur_psf)
+            self.update_psf_blur(blur_psf)
+            blur_psf_values = np.array(config['psf']['psf_blur_factors']) * blur_psf
         else:
-            logger.info(f'Using original PSF without blurring')
+            logger.debug(f'Using original PSF without blurring')
+            blur_psf_values = None
             
         x0 = self.cutoutdata.sersic_params_physical['x_0']
         y0 = self.cutoutdata.sersic_params_physical['y_0']
@@ -82,6 +112,8 @@ class PSFFitter():
                 self.psf_sigma,
                 threshold_list = threshold_list,
                 center_mask_params=center_mask_params,
+                psf_blur_values = blur_psf_values,
+                psf_blur_func = self.update_psf_blur,
                 **kwargs)
             
         psf_model_total = self.data - resid
@@ -192,7 +224,7 @@ def filter_psfphot_results(phot_result,
     qfit = phot_result['qfit']
     x_diff = phot_result['x_fit'] - phot_result['x_init']
     y_diff = phot_result['y_fit'] - phot_result['y_init']
-    npixfit = phot_result['npixfit']
+    npixfit = phot_result['n_pixels_fit']
     xerr = phot_result['x_err']
     yerr = phot_result['y_err']
 
@@ -402,15 +434,14 @@ def _prepare_psf_fitters(th,psf_model,bkg_std,psf_sigma):
     psf_iter = None # TODO remove this
     
     psf_single = PSFPhotometry(
-        psf_model, 
+        psf_model,
+        fit_shape          = config['psf']['PSFPhotometry_fit_shape'],
         finder             = daofinder,
         grouper            = grouper,
-        localbkg_estimator = localbkg_estimator,
-        fit_shape       = config['psf']['PSFPhotometry_fit_shape'],
-        aperture_radius = config['psf']['PSFPhotometry_aperture_radius'],
-        fitter_maxiters = config['psf']['PSFPhotometry_fitter_maxiters'],
+        local_bkg_estimator= localbkg_estimator,
+        aperture_radius    = config['psf']['PSFPhotometry_aperture_radius'],
+        fitter_maxiters    = config['psf']['PSFPhotometry_fitter_maxiters'],
         group_warning_threshold = config['psf']['PSFPhotometry_group_warning_threshold'],
-        multiprocessing = config['psf']['PSFPhotometry_multiprocessing'],
     )
     return psf_iter, psf_single
 
@@ -464,8 +495,9 @@ def do_psf_photometry(data,data_error,bkg_std,
             # fit all simultaneously
             phot_result = psf_single(data, error=data_error) # init_params=init_params)
         except AstropyUserWarning as e:
-            logger.error(f'Too many blended sources. Aborting th={th}...')
-            raise
+            # logger.error(f'Too many blended sources. Aborting th={th}...')
+            N_blend = config['psf']['PSFPhotometry_group_warning_threshold']
+            raise Exception(f'too many (>{N_blend}) blended sources.')
         except Exception as e:
             logger.info(f'IterativePSFPhotometry failed due to: {str(e)}')
             raise 
@@ -503,9 +535,26 @@ def iterative_psf_fitting(data,psf_model,psf_sigma,
                           threshold_list,
                           progress=None,
                           progress_text='Running iPSF...',
+                          psf_blur_values = None,
+                          psf_blur_func = None,
                           **kwargs):
     ''' Iteratively run do_psf_photometry() with different threshold levels.
-    This function is useful for crowded fields, where a single threshold level may fail. '''
+    This function is useful for crowded fields, where a single threshold level may fail. 
+    
+    Inputs:
+        data (2d array): the data to perform PSF photometry.
+        psfimg (2d array): the PSF image.
+        psf_sigma (float): the HWHM of the PSF. Use FWHM/2
+        psf_oversample (int): the oversampling factor of the PSF.
+        threshold_list (1d array): the list of threshold levels to try, in background STD.
+        center_mask_params (list, optional): [x_center,y_center,mask_r]. If provided, sources within the radius mask_r from (x_center,y_center) will be excluded from the final results. This is useful when the central source is very bright and causes many spurious detections nearby.
+        psf_blur_fpsf_blur_valuesactors (list, optional): the list of Gaussian sigma values to convolve the PSF with, in pixel units. If provided, the PSF will be convolved with the Gaussian kernel at the end of the iterative fitting to check if any additional sources can be found/fitted with dfferent PSF widths. If not provided, this additional check will not be performed.
+        psf_blur_func (function, optional): the function to convolve the PSF with a Gaussian kernel. The function should take a single argument (the sigma value) and output the convolved PSF. If not provided, this additional check will not be performed.
+        kwargs (dict): additional kwargs to pass to do_psf_photometry.
+    Returns:    
+        phot_result (QTable): the combined photometry result from all iterations.
+        resid_all (2d array): the final residual image.
+    '''
       
     # prepare background-subtracted data
     # take data stats & prepare background-subtracted data
@@ -519,10 +568,11 @@ def iterative_psf_fitting(data,psf_model,psf_sigma,
     # initialize variables
     resid = data_bksub.copy()
     phot_result = None
+    last_successful_th = None
 
     # loop -- repeat PSF subtraction
     if progress is not None:
-        progress_psf = progress.add_task(progress_text, 
+        progress_psf = progress.add_task(progress_text,
                                         total=len(threshold_list))
     for th in threshold_list:
         try:
@@ -543,6 +593,7 @@ def iterative_psf_fitting(data,psf_model,psf_sigma,
                     phot_result = _phot_result
                 else:
                     phot_result = vstack([phot_result, _phot_result])
+                last_successful_th = th
         except Exception as e:
             if config['psf']['raise_error']:
                 raise 
@@ -550,6 +601,45 @@ def iterative_psf_fitting(data,psf_model,psf_sigma,
             continue
     if progress is not None:
         progress.remove_task(progress_psf)
+
+    # optional override: use a fixed threshold for the PSF-blur sweep
+    psf_blur_th_override = config['psf'].get('psf_blur_th', None)
+    if psf_blur_th_override is not None:
+        last_successful_th = psf_blur_th_override
+
+    # additional loop -- repeat PSF subtraction with different PSF widths
+    if (psf_blur_values is not None) and (psf_blur_func is not None) and (last_successful_th is not None):
+        if progress is not None:
+            progress_psf = progress.add_task(f'Fitting at th={last_successful_th:.2f} with sharper and blurrier PSF...', 
+                                            total=len(psf_blur_values))
+        for psf_blur in psf_blur_values:
+            try:
+                psf_model,psf_sigma = psf_blur_func(psf_blur)
+                psf_results = do_psf_photometry(resid, data_error, bkg_std, 
+                                                psf_model, psf_sigma,
+                                                th=last_successful_th,**kwargs)
+                if progress is not None:
+                    progress.update(progress_psf, advance=1, refresh=True)
+                if psf_results[0] is None:
+                    continue
+                else:
+                    _phot_result, _resid = psf_results
+                    if np.all(~np.isfinite(_resid)):
+                        continue
+                    # append the results
+                    resid = _resid
+                    if phot_result is None:
+                        phot_result = _phot_result
+                    else:
+                        phot_result = vstack([phot_result, _phot_result])
+            except Exception as e:
+                if config['psf']['raise_error']:
+                    raise 
+                logger.error(f'Skipping PSF fitting with th={th:.2f}, blur={psf_blur}. {str(e)}')
+                continue
+
+        if progress is not None:
+            progress.remove_task(progress_psf)
         
     # make the residual image without background subtraction
     psf_modelimg_all = data_bksub - resid


### PR DESCRIPTION
## Summary

Makes sphot compatible with **photutils 3.0.0** (tested on py313 + astropy 7.2 + numpy 2.4). Before this change, `PSFPhotometry.__init__()` rejects the `multiprocessing` kwarg and every PSF pass in `run_basefit` / `run_scalefit` fails.

### photutils v3 changes

| File | Change |
|------|--------|
| `sphot/psf.py` | Remove `multiprocessing` kwarg from `PSFPhotometry` (removed in v3); rename `localbkg_estimator` → `local_bkg_estimator`; read `n_pixels_fit` column instead of `npixfit` |
| `sphot/aperture.py` | `photutils.psf.matching` → `photutils.psf_matching`; `create_matching_kernel` → `make_kernel` |
| `sphot/data.py` | `DAOStarFinder` now uses `roundness_range` / `sharpness_range` tuples |
| `sphot/default_config.toml` | `finder_kwargs` uses new names; `PSFPhotometry_multiprocessing` removed |

### Save-path fixes surfaced by v3

`EllipticalAperture.theta` is now an `astropy.units.Quantity` — that broke `MultiBandCutout.save` when called from `run_sphot --photometry`.

- `str_to_json` handles empty lists (was `IndexError`) and coerces `Quantity` → bare value.
- `MultiBandCutout.save` wraps the top-level attribute write in the same try/except the inner `CutoutData` loop already had.

### Also riding along

The commit also includes in-progress work that was already uncommitted on `main` and is **unrelated to the photutils migration**:

- PSF-blur sweep around the last successful threshold (`psf.py`)
- Plot-failure-tolerant `aperture_routine`; `title` kwarg on `CutoutDataPhotometry.plot` (`aperture.py`)
- `median`-fallback branch in `fill_nans` when `replace_with='median'`
- `psf_blur_factors`, `fill_replace_with` config entries

Plus one **bug fix in that new PSF-blur sweep**: it had an unconditional `config['psf']['psf_blur_th']` lookup that crashes with `KeyError` because the key isn't in the default config. The sweep now initializes `last_successful_th = None`, skips the extra pass when no threshold ever succeeded, and treats `psf_blur_th` as an optional override.

### Verification

Full pipeline on `sample_data/g260.h5`, all 6 filters: load → basefit → scalefit → aperphot → save → reload round-trip. With photutils deprecation warnings escalated to errors, the pipeline runs clean.

Sample output:
```
F555W: mag_raw=24.619 ± 0.065   mag_corr=24.637 ± 0.067
F814W: mag_raw=22.101 ± 0.011   mag_corr=22.078 ± 0.018
F090W: mag_raw=21.713 ± 0.010   mag_corr=21.713 ± 0.018
F150W: mag_raw=20.649 ± 0.007   mag_corr=20.650 ± 0.016
F160W: mag_raw=21.088 ± 0.012   mag_corr=20.633 ± 0.021
F277W: mag_raw=20.235 ± 0.005   mag_corr=20.002 ± 0.016
```

### Note on pyproject.toml

`dependencies` still says `photutils>=1.13`. I left it alone — bumping the floor to `>=3.0` is a separate decision about whether to drop support for older installs. Happy to add that in a follow-up if you'd like.

## Test plan

- [x] `sphot` imports on py313 + photutils 3.0.0
- [x] `run_basefit` on `sample_data/g260.h5` (F150W)
- [x] `run_scalefit` across F555W / F814W / F090W / F160W / F277W
- [x] `run_aperphot` incl. PSF-matched corrections (F090W base)
- [x] `galaxy.save()` + `read_sphot_h5()` round-trip preserves aperture params
- [x] Zero photutils DeprecationWarnings / FutureWarnings / AstropyDeprecationWarnings fire during a full pipeline run