### PR TITLE
Fix #10: deep-merge user config sections

### DIFF
--- a/sphot/config.py
+++ b/sphot/config.py
@@ -13,7 +13,13 @@ def load_config(user_config_path = 'sphot_config.toml'):
     if os.path.exists(user_config_path):
         with open(user_config_path, 'rb') as f:
             user_config = tomllib.load(f)
-            config.update(user_config)
+        for section, overrides in user_config.items():
+            if (section in config
+                    and isinstance(config[section], dict)
+                    and isinstance(overrides, dict)):
+                config[section].update(overrides)
+            else:
+                config[section] = overrides
         logger.info(f'User config file loaded: {user_config_path}')
     else:
         logger.info(f'Using the default config file: {default_config_path}')


### PR DESCRIPTION
## Summary
- `load_config` used a shallow `dict.update`, so a partial user `[psf]` block wiped every other `[psf]` default (e.g. `bkg_sigma_clip`, `bkg_box_size`, `bkg_filter_size`).
- Switch to a per-section merge: user overrides layer on top of defaults within each section, brand-new sections are still added as-is.

## Test plan
- [x] Reproduced original behaviour: partial `[psf] th_min = 5` reduced `config['psf']` to just `th_min`.
- [x] After fix: `th_min = 5` is applied and all other `[psf]` defaults (`bkg_sigma_clip`, etc.) are preserved.

Closes #10