### PR TITLE
Fix #13: pass (x, y) size to petrofit.model_to_image

### DIFF
--- a/sphot/fitting.py
+++ b/sphot/fitting.py
@@ -141,10 +141,13 @@ class ModelFitter():
     def eval_model(self,standardized_params):
         ''' render the model image based on the given parameters '''
         params = self.unstandardize_params(standardized_params)
-        
+
         parsed_params = self.model.parse_params(params)
         self.model.parameters = parsed_params
-        _img = model_to_image(self.model, size=self.data.shape)
+        # petrofit.model_to_image takes size as (x_size, y_size); numpy
+        # shape is (rows, cols) = (y, x), so reverse before passing.
+        ny, nx = self.data.shape
+        _img = model_to_image(self.model, size=(nx, ny))
         return _img
 
     def calc_chi2(self,


### PR DESCRIPTION
## Summary
- \`ModelFitter.eval_model\` passed \`size=self.data.shape\` to \`petrofit.model_to_image\`. But \`model_to_image\` documents \`size\` as \`(x_size, y_size)\` — explicitly the reverse of numpy's \`shape\`. So the model image was rendered with axes swapped.
- On square cutouts the shapes happen to match, but the model values are still wrong (Sersic ellipticity axes effectively rotated 90°).
- On non-square cutouts, \`calc_chi2\`'s \`self.data - model_img\` raised \`ValueError\` on a \`(M,N)\` vs \`(N,M)\` broadcast.

Fix: pass \`(nx, ny)\` from \`self.data.shape\`.

## Test plan
- [x] Reproduced \`ValueError: operands could not be broadcast together with shapes (342,335) (335,342)\` on a non-square shape.
- [x] After the fix: \`eval_model\` returns shape \`(342, 335)\` matching \`self.data\`; subtraction succeeds; argmax of a Sersic at \`x_0=170, y_0=170\` lands at \`(row=170, col=170)\` as expected.

Closes #13