### PR TITLE
Fix #14: guard against degenerate Sersic r_eff → EllipticalAperture crash

### DIFF
--- a/sphot/fitting.py
+++ b/sphot/fitting.py
@@ -80,7 +80,11 @@ class SphotModel(PSFConvolvedModel2D):
             elif 'amplitude' in key:
                 bounds.append([0,np.nanmax(data)])
             elif 'r_eff' in key:
-                bounds.append([0,data.shape[0]])
+                # Strictly positive: downstream EllipticalAperture
+                # construction (sigma_clip_outside_aperture) requires
+                # r_eff > 0. Sub-pixel r_eff has no physical meaning
+                # for galaxy cutouts either way.
+                bounds.append([0.5,data.shape[0]])
             elif 'n' in key:
                 bounds.append([0.1,10])
             elif 'ellip' in key:

--- a/sphot/psf.py
+++ b/sphot/psf.py
@@ -279,7 +279,12 @@ def sigma_clip_outside_aperture(data,sersic_params_physical,clip_sigma=4,
     y_0 = sersic_params_physical['y_0']
     ellip = sersic_params_physical['ellip']
     theta = sersic_params_physical['theta']
-    b = (1 - ellip) * a
+    # Defensive clamps: EllipticalAperture requires a,b > 0. A degenerate
+    # Sersic fit (r_eff → 0 or ellip → 1) would otherwise crash the
+    # pipeline here. Floor at 1 px so the aperture covers at least the
+    # central pixel; downstream this just means a 1-pixel core mask.
+    a = max(float(a), 1.0)
+    b = max((1 - float(ellip)) * a, 1.0)
     aperture = EllipticalAperture((x_0, y_0), a, b, theta=theta)
     # aperture = CircularAperture((data.shape[0]/2,data.shape[1]/2),
     #                             r_eff*aper_size_in_r_eff)


### PR DESCRIPTION
## Summary
\`ValueError: 'a' must be a positive scalar\` was raised inside \`run_basefit\` when a Sersic fit converged to \`r_eff ≈ 0\`. The error originates in \`photutils.aperture.EllipticalAperture(a=0)\`, constructed by \`sigma_clip_outside_aperture\` from \`cd.sersic_params_physical\`.

Root cause: \`SphotModel.get_bounds()\` allowed \`r_eff\` in \`[0, data.shape[0]]\`, so iNM could land exactly at the singularity.

- Bump the \`r_eff\` lower bound from \`0\` to \`0.5\` px. Sub-pixel \`r_eff\` has no physical meaning for galaxy cutouts.
- Defensively clamp \`a, b ≥ 1\` px in \`sigma_clip_outside_aperture\` so any remaining degenerate fit (e.g. \`ellip → 1\` forcing \`b → 0\`) doesn't crash the pipeline.

## Test plan
- [x] Reproduced \`ValueError: 'a' must be a positive scalar\` by calling \`sigma_clip_outside_aperture\` with \`sersic_params_physical['r_eff'] = 0\`.
- [x] After the fix: same call succeeds (mask returns empty as expected); also tested with \`ellip = 1.0\` (b → 0 degenerate case), no crash.
- [x] \`get_bounds()\` returns \`r_eff: [0.5, data.shape[0]]\` after fix.

Closes #14