### PR TITLE
Fix #15: fill_nans handles replace_with='median' (the default)

### DIFF
--- a/sphot/aperture.py
+++ b/sphot/aperture.py
@@ -214,8 +214,13 @@ def fill_nans(galaxy,apertures,
                     s = ~np.isfinite(data) & mask
                     if s.sum() == 0:
                         continue
-                    # elif s.sum() <= max_nan_frac * mask.sum():
-                    data_filled[s] = getattr(cutoutdata,replace_with)[s].copy()
+                    if replace_with == 'median':
+                        # Mirror the i>0 path: CutoutData has no 'median'
+                        # attribute, so compute it locally from the finite
+                        # pixels inside the innermost aperture.
+                        data_filled[s] = np.nanmedian(data[mask])
+                    else:
+                        data_filled[s] = getattr(cutoutdata,replace_with)[s].copy()
                     logger.warning('NaN pixels exists near the center. Replacing with the reference image')
                     # else:
                         # logger.error('NaN pixels near the center...')


### PR DESCRIPTION
## Summary
\`default_config.toml\` sets \`fill_replace_with = 'median'\`, but the \`i==0\` (innermost-aperture) branch of \`fill_nans\` did \`getattr(cutoutdata, 'median')\` — and \`CutoutData\` has no \`median\` attribute. So every galaxy with NaN pixels inside its innermost aperture (e.g. ACS coverage edges, chip gaps) crashed during \`--photometry\` with \`AttributeError\`.

The \`i>0\` branches already handle the \`'median'\` mode by computing \`np.nanmedian\` of the local annulus. Mirror that into the \`i==0\` path: compute the median of finite pixels inside the innermost aperture mask. Fall back to \`getattr(...)\` for any other \`replace_with\` value.

## Test plan
- [x] Confirmed \`CutoutData\` exposes no \`median\` attribute (so the old code was unreachable on the default config).
- [x] Reproduced the path with a synthetic 60×60 cutout with NaN pixels at the centre and \`replace_with='median'\`; the new code fills the NaNs with the local median (\`9.97\` for a \`N(10,1)\` field) and leaves zero NaNs in the inner region.

Closes #15