### PR TITLE
Fix #16: sort + dedupe xdata before csaps in get_aper_at

### DIFF
--- a/sphot/aperture.py
+++ b/sphot/aperture.py
@@ -415,7 +415,18 @@ class IsoPhotApertures():
             xdata = getattr(self,x_attr)
             ydata = self.petro_idx
             s = np.isfinite(xdata) & np.isfinite(ydata)
-            interp_func = csaps(xdata[s],ydata[s],normalizedsmooth=True)
+            # csaps requires xdata to be strictly increasing. The isophote
+            # sampling can produce non-monotonic / duplicate semi-major axes
+            # (noisy fits or plateaus), so sort + dedupe before constructing.
+            x_finite = xdata[s]
+            y_finite = ydata[s]
+            order = np.argsort(x_finite)
+            x_sorted = x_finite[order]
+            y_sorted = y_finite[order]
+            unique_mask = np.r_[True, np.diff(x_sorted) > 0]
+            interp_func = csaps(x_sorted[unique_mask],
+                                y_sorted[unique_mask],
+                                normalizedsmooth=True)
             y_interp = interp_func(xdata,extrapolate=False)
             self.petro_idx_interp = y_interp
 


### PR DESCRIPTION
## Summary
\`csaps.CubicSmoothingSpline\` requires \`xdata\` to satisfy \`x1 < x2 < ... < xN\`. \`IsoPhotApertures.get_aper_at\` passed \`xdata[s]\` directly, where \`xdata\` is the isophote-fit \`semi_major_axes\` array — that array can be locally non-monotonic or contain duplicates (noisy fits, plateaus), which raises \`ValueError\` inside csaps.

Sort + dedupe \`(xdata, ydata)\` after the finite-value mask, then construct csaps from the cleaned arrays. The downstream \`interp_func(xdata, ...)\` still works on the original (unsorted) \`xdata\` because csaps only constrains the construction inputs.

## Test plan
- [x] Reproduced \`ValueError: Items of 'xdata' vector must satisfy the condition: x1 < x2 < ... < xN\` directly with a non-monotonic \`xdata\` array.
- [x] After fix, \`get_aper_at(petro=0.5)\` succeeds on a non-monotonic-with-NaN \`semi_major_axes\` array.
- [x] Also tested duplicate-only inputs (\`x = [1.0, 1.0, 2.0, 3.0]\`): handled cleanly.

Closes #16