### PR TITLE
psf-calib: turn in_mainloop on by default

### DIFF
--- a/sphot/default_config.toml
+++ b/sphot/default_config.toml
@@ -20,7 +20,7 @@ use_dual_annealing = true              # iter-1 main-loop sersic fit: short iNM 
 use_final_polish = true                # post-mainloop L-BFGS-B polish on the final sersic params
 
 [psf-calib]
-in_mainloop = false                    # enable per-iter kernel recalibration
+in_mainloop = true                     # per-iter kernel recalibration (set false to disable)
 kernel_family = 'gaussian'             # 'gaussian' | 'moffat' | 'drizzle'
 kernel_anchor_K = 30                   # # of brightest anchors used in the kernel fit
 kernel_fit_skip_on_convergence = false # if true, skip fwhm scan once kernel L2 stable


### PR DESCRIPTION
## Summary
The in-loop PSF calibrator (\`sphot/calibrate_psf.py\`) shipped with v0.3.0 but was left opt-in (\`in_mainloop = false\`) in the release config. Combined with the v0.3.0 \`[prep] blur_psf = {}\` default (which removed V1's per-filter hardcoded blurs), a default-config run applies **no PSF blur path at all**: \`cd.psf\` stays at the raw library PSF, photometry under-subtracts wings, and fluxes are biased downward.

## Evidence
Confirmed on the DDU2 PSF-calibration repro bundle (\`sphot_psfcal_repro_2026-05-15.zip\`): for every affected filter across **N3447/g005**, **N3370/g005**, **N5643/g002**, the saved \`cd.psf\` in \`*_sphot_v03.h5\` is byte-identical (after normalization) to the corresponding entry in \`psf_data.h5\`. The calibrator never fired.

E.g. N5643/g002 F277W encircled-energy comparison:

| r (px) | v03 (no blur) | v1 (blur_psf=8) |
|---:|---:|---:|
| 2  | 0.180 | 0.022 |
| 5  | 0.600 | 0.131 |
| 10 | 0.766 | 0.408 |
| 20 | 0.873 | 0.805 |

V03's wings carry almost no flux relative to V1 — the model PSF is missing the empirical broadening that V1's hardcoded \`blur_psf\` was supplying.

## Change
\`\`\`diff
 [psf-calib]
-in_mainloop = false                    # enable per-iter kernel recalibration
+in_mainloop = true                     # per-iter kernel recalibration (set false to disable)
\`\`\`

Users who want the old (library-as-is) behaviour can still set \`in_mainloop = false\`.

## Test plan
- [x] \`from sphot.config import config\` → \`config['psf-calib']['in_mainloop'] is True\` from a clean cwd.
- [ ] (Follow-up) Re-run sphot on the 3 repro cases with this default and confirm calibrator picks per-filter blurs comparable to V1's hardcoded values.