### PR TITLE
Fix #26, #27, #28: typed DegenerateCutoutError for degenerate-cutout failures

### DIFF
--- a/sphot/aperture.py
+++ b/sphot/aperture.py
@@ -423,6 +423,20 @@ class IsoPhotApertures():
             order = np.argsort(x_finite)
             x_sorted = x_finite[order]
             y_sorted = y_finite[order]
+            # Need at least 2 finite, distinct x to construct the smoothing
+            # spline. `np.r_[True, np.diff(x_sorted)>0]` is always length
+            # max(1, len(x_sorted)), so an empty x_sorted gives a length-1
+            # mask that can't index an empty array -> generic IndexError.
+            # Bail out with a typed error so the caller can skip the cutout.
+            if x_sorted.size < 2:
+                # local import: aperture.py is imported by data.py, so a
+                # module-level `from .data import ...` would be circular.
+                from .data import DegenerateCutoutError
+                raise DegenerateCutoutError(
+                    f'get_aper_at: insufficient finite ({x_attr}, petro_idx) '
+                    f'samples ({x_sorted.size}) to construct the interpolator; '
+                    f'isophote sampling is too degenerate.'
+                )
             unique_mask = np.r_[True, np.diff(x_sorted) > 0]
             interp_func = csaps(x_sorted[unique_mask],
                                 y_sorted[unique_mask],

--- a/sphot/data.py
+++ b/sphot/data.py
@@ -8,6 +8,7 @@ import logging
 from tqdm.auto import tqdm
 import h5py
 import json
+import warnings
 
 from scipy.optimize import minimize, leastsq
 from scipy import stats
@@ -35,7 +36,19 @@ class DebugException(Exception):
     def __init__(self, message, debug_var):
         super().__init__(message)
         self.debug_var = debug_var
-        
+
+
+class DegenerateCutoutError(ValueError):
+    """Raised when a CutoutData step cannot proceed because the cutout is
+    too degenerate (e.g. mostly-NaN data, insufficient finite isophote
+    samples, or a required intermediate attribute hasn't been produced
+    yet). Subclass of `ValueError` so existing `except ValueError:`
+    handlers keep working; SLURM array tasks can catch this specifically
+    to skip + record the cutout instead of aborting.
+    """
+    pass
+
+
 
 def calc_mag(counts_Mjy_per_Sr,errors_Mjy_per_Sr=None,pixel_scale=0.03):
     PIXAR_SR = ((pixel_scale*u.arcsec)**2).to(u.sr).value
@@ -187,12 +200,23 @@ class CutoutData():
             bounds = ([shape/2 - center_slack*shape,0,0,-np.inf],
                       [shape/2 + center_slack*shape,shape,np.inf,np.inf])
 
-            # clip pixels when the counts are too low
-            lower_clip = np.nanpercentile(means_smooth,
-                                          clip_lower_counts_percentile)
-            s2 = means_smooth > lower_clip
-            s2 = s2 & np.isfinite(means_smooth)
-            
+            # clip pixels when the counts are too low. `nanpercentile` of an
+            # all-NaN means_smooth returns NaN, which makes the `>` comparison
+            # all-False and `s2` empty -> `means_smooth[s2].max()` would raise
+            # a generic "zero-size array" ValueError deep in numpy. Catch it
+            # here as DegenerateCutoutError so SLURM callers can skip cleanly.
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', category=RuntimeWarning)
+                lower_clip = np.nanpercentile(means_smooth,
+                                              clip_lower_counts_percentile)
+            s2 = (means_smooth > lower_clip) & np.isfinite(means_smooth)
+            if s2.sum() == 0:
+                raise DegenerateCutoutError(
+                    f'init_size_guess: no usable smoothed-profile samples '
+                    f'on axis={axis} (means_smooth all-NaN or below clip); '
+                    f'cutout is too degenerate for a Gaussian size guess.'
+                )
+
             x0_guess = axis_pixels.max()/2
             p0 = [x0_guess,sigma_guess, # center, sigma,
                   means_smooth[s2].max()-means_smooth[s2].min(), # amplitude

--- a/sphot/data.py
+++ b/sphot/data.py
@@ -280,7 +280,23 @@ class CutoutData():
         
     def remove_sky(self,fit_to='residual_masked',remove_from='psf_sub_data',**kwargs):
         N_repeat = kwargs.get('repeat',1)
-        
+
+        # Validate `remove_from` attributes up-front. The default
+        # 'psf_sub_data' only exists after PSFFitter.fit has run; callers in
+        # the main loop sometimes invoke remove_sky before that (e.g. when an
+        # earlier stage like the isophote fit fails silently and the pipeline
+        # tries to continue). Detect this and raise a typed error instead of
+        # letting `getattr` fall through with a generic AttributeError so the
+        # pipeline can catch + skip the cutout.
+        attrs = [str(a) for a in np.atleast_1d(np.squeeze(remove_from))]
+        missing = [attr for attr in attrs if not hasattr(self, attr)]
+        if missing:
+            raise DegenerateCutoutError(
+                f'remove_sky: requested remove_from attr(s) {missing} not yet '
+                f'set on CutoutData (likely an earlier pipeline stage failed '
+                f'or has not run). Cannot subtract sky.'
+            )
+
         # sky model = sum of all sky models fitted during the iterations
         sky_model_total = np.zeros_like(self.data)
         for _ in range(N_repeat):
@@ -288,7 +304,7 @@ class CutoutData():
             sky_model_total += self.sky_model
             for attr in np.atleast_1d(np.squeeze(remove_from)):
                 _data = getattr(self,attr)
-                setattr(self,attr,_data-self.sky_model)    
+                setattr(self,attr,_data-self.sky_model)
         self.sky_model = sky_model_total
     
     def fit_sky(self,fit_to='residual_masked',poly_deg=1,


### PR DESCRIPTION
Fixes #26, #27, #28.

All three open issues are crash-on-degenerate-cutout failures from the
DDU2_tests pipeline-01 (artphot) SLURM array runs. Common motivation:
let the array task **skip** a degenerate cutout cleanly (typed
exception) instead of aborting on an opaque numpy/AttributeError.

## Shared infrastructure

Add `sphot.data.DegenerateCutoutError`, a subclass of `ValueError`.
SLURM callers can `except DegenerateCutoutError:` to skip + record the
cutout, and existing `except ValueError:` handlers still catch it.

## Per-issue fixes

### Fix #26 — `init_size_guess` zero-size array
When some pixels are finite but the smoothed/averaged profile
`means_smooth` is all-NaN, `nanpercentile` returns NaN → `s2` empty →
`means_smooth[s2].max()` raised a generic numpy reduction error. The
existing `np.isfinite(self.data).sum() == 0` guard only caught the
fully-empty case. Add an explicit `s2.sum() == 0` guard in both axis
loops; suppress the cosmetic `nanpercentile` all-NaN `RuntimeWarning`.

### Fix #27 — `remove_sky` missing attribute
`remove_sky` defaults `remove_from='psf_sub_data'`, which only exists
after `PSFFitter.fit` has run. When an earlier stage fails silently
(e.g. `photutils.isophote` "Too small sample to warrant a fit"),
`getattr(self, attr)` raised a generic `AttributeError`. Validate the
requested `remove_from` attrs up-front; raise `DegenerateCutoutError`
listing the missing names.

### Fix #28 — `get_aper_at` empty interpolator input
The sort + dedupe block from #16 / d482cff handles non-monotonic and
duplicate semi-major axes, but doesn't guard against zero or one
finite `(xdata, ydata)` pair. `np.r_[True, np.diff(x_sorted) > 0]` is
always length `max(1, len(x_sorted))`, so an empty `x_sorted` plus a
length-1 mask raised a generic `IndexError`. csaps needs ≥ 2 distinct
samples anyway. Add an `x_sorted.size < 2` guard. The import of
`DegenerateCutoutError` is function-local because `aperture.py` is
imported by `data.py` (a module-level import would be circular).

## Validation

Each fix was smoke-tested interactively with synthetic degenerate
inputs (all-NaN data, missing `psf_sub_data`, all-NaN semi-major
axes). Pre-fix all three raised the original opaque numpy / built-in
errors; post-fix all three raise `DegenerateCutoutError` with a
descriptive message. Subclassing `ValueError` is verified to keep
existing handlers working.
